### PR TITLE
Setup a named logger for the module

### DIFF
--- a/src/compact_json/_compact_json.py
+++ b/src/compact_json/_compact_json.py
@@ -2,9 +2,10 @@ import argparse
 import json
 import logging
 
+import compact_json
 from compact_json import EolStyle, Formatter, _get_version
-from compact_json.formatter import logger
 
+logger = logging.getLogger(compact_json.__name__)
 
 def command_line_parser():
     parser = argparse.ArgumentParser(

--- a/src/compact_json/_compact_json.py
+++ b/src/compact_json/_compact_json.py
@@ -1,5 +1,6 @@
 import argparse
 import json
+import logging
 
 from compact_json import EolStyle, Formatter, _get_version
 from compact_json.formatter import logger
@@ -121,6 +122,9 @@ def main():  # noqa: C901
         formatter.east_asian_string_widths = args.east_asian_chars
         formatter.ensure_ascii = not args.no_ensure_ascii
 
+        hdlr = logging.StreamHandler()
+        hdlr.setFormatter(logging.Formatter('%(levelname)s:%(name)s:%(message)s'))
+        logger.addHandler(hdlr)
         if args.debug:
             logger.setLevel('DEBUG')
         else:

--- a/src/compact_json/_compact_json.py
+++ b/src/compact_json/_compact_json.py
@@ -122,9 +122,9 @@ def main():  # noqa: C901
         formatter.ensure_ascii = not args.no_ensure_ascii
 
         if args.debug:
-            logging.getLogger().setLevel(logging.DEBUG)
+            logging.getLogger('compact_json').setLevel(logging.DEBUG)
         else:
-            logging.getLogger().setLevel(logging.ERROR)
+            logging.getLogger('compact_json').setLevel(logging.ERROR)
 
         formatter.table_dict_minimum_similarity = 30
         formatter.table_list_minimum_similarity = 50

--- a/src/compact_json/_compact_json.py
+++ b/src/compact_json/_compact_json.py
@@ -1,8 +1,8 @@
 import argparse
 import json
-import logging
 
 from compact_json import EolStyle, Formatter, _get_version
+from compact_json.formatter import logger
 
 
 def command_line_parser():
@@ -122,9 +122,9 @@ def main():  # noqa: C901
         formatter.ensure_ascii = not args.no_ensure_ascii
 
         if args.debug:
-            logging.getLogger('compact_json').setLevel(logging.DEBUG)
+            logger.setLevel('DEBUG')
         else:
-            logging.getLogger('compact_json').setLevel(logging.ERROR)
+            logger.setLevel('ERROR')
 
         formatter.table_dict_minimum_similarity = 30
         formatter.table_list_minimum_similarity = 50

--- a/src/compact_json/formatter.py
+++ b/src/compact_json/formatter.py
@@ -1,11 +1,11 @@
 import json
+import logging
 import warnings
-
 from dataclasses import dataclass
 from decimal import Decimal, InvalidOperation
 from enum import Enum
-import logging
 from typing import List
+
 from wcwidth import wcswidth
 
 debug = logging.getLogger('compact_json').debug

--- a/src/compact_json/formatter.py
+++ b/src/compact_json/formatter.py
@@ -4,10 +4,11 @@ import warnings
 from dataclasses import dataclass
 from decimal import Decimal, InvalidOperation
 from enum import Enum
-from logging import debug
+import logging
 from typing import List
 from wcwidth import wcswidth
 
+debug = logging.getLogger('compact_json').debug
 
 class EolStyle(Enum):
     CRLF = 1

--- a/src/compact_json/formatter.py
+++ b/src/compact_json/formatter.py
@@ -8,7 +8,8 @@ from typing import List
 
 from wcwidth import wcswidth
 
-debug = logging.getLogger('compact_json').debug
+logger = logging.getLogger(__name__)
+debug = logger.debug
 
 class EolStyle(Enum):
     CRLF = 1

--- a/tests/test_console_script.py
+++ b/tests/test_console_script.py
@@ -104,6 +104,6 @@ def test_help(script_runner):
 
 def test_debug(script_runner):
     ret = script_runner.run("compact-json", "--debug", "tests/data/test-1.json")
-    assert "DEBUG:root:format_table_dict_list" in ret.stderr
+    assert "DEBUG:compact_json.formatter:format_table_dict_list" in ret.stderr
     assert ret.success
     assert '"title": "Sample Konfabulator Widget"' in ret.stdout


### PR DESCRIPTION
The original code uses `logging.debug` for logging, which may cause trouble when users uses the builtin log functions for other purpose. 
I now use `logger = logging.getLogger(__name__)` so that it won't affect other loggers. Also, one can configure logging settings for this module separately in this way.