### PR TITLE
Add an --in-place editing option

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -52,6 +52,7 @@ Testing and configuration is based on [Poetry](https://python-poetry.org) and is
 You should also verify that existing [tests](./tests) are still working and you are encouraged to add new ones. You are also encouraged to add tests that at least maintain the current level of code coverage. You can run the tests using the following commands from the root folder:
 
 ```bash
+poetry install    # Only required the first time
 poetry run pytest
 ```
 

--- a/README.md
+++ b/README.md
@@ -123,7 +123,7 @@ When installed from `pip` a command-line utility `compact-json` is installed whi
 
 ``` shell
 usage:     compact-json [-h] [-V]
-                        [--output-filename [OUTPUT_FILENAME ...]]
+                        [--output [OUTPUT_FILENAME ...]]
                         [--crlf] [--max-inline-length N]
                         [--max-inline-complexity N]
                         [--max-compact-list-complexity N]
@@ -140,10 +140,11 @@ positional arguments:
 optional arguments:
   -h, --help            show this help message and exit
   -V, --version
-  --output-filename [OUTPUT_FILENAME ...], -out [OUTPUT_FILENAME ...]
+  --output              [OUTPUT_FILENAME ...], -out [OUTPUT_FILENAME ...]
                         The output file name(s). If empty, no new JSON file(s)
                         will be saved. If provided, the number of output file
                         names must match that of the input files.
+  --in-place            Save any edits back to the input file
   --crlf                Use Windows-style CRLF line endings
   --max-inline-length N
                         Limit inline elements to N chars, excluding


### PR DESCRIPTION
Adds the --in-place command line option to save back edits to the input file without needing to name all the input files twice using --output.
    
We had to restructure the CLI file flow quite a bit because we don't want to touch the output file if running in-place and if the contents haven't changed. (And because argparse.FileType is now deprecated.)